### PR TITLE
new command 'info unsimulated'

### DIFF
--- a/src/simset/command_line.py
+++ b/src/simset/command_line.py
@@ -1,5 +1,5 @@
 from typing import Callable
-from simset.initialize import init, clean, info, info_unfinished, out, error
+from simset.initialize import init, clean, info, info_unsimulated, out, error
 from simset.parser import _parse_arguments, simulate_process_parser
 from simset.simulate import simulate, simulate_setup, _get_unsimulated_args
 from simset.post_processing import post_processing
@@ -89,8 +89,8 @@ def command_line_simulate_process(
         error(args.index)
         exit(0)
     elif args.action == 'info':
-        if args.command == "unfinished":
-            info_unfinished()
+        if args.command == "unsimulated":
+            info_unsimulated()
         else:
             info()
         exit(0)

--- a/src/simset/command_line.py
+++ b/src/simset/command_line.py
@@ -1,5 +1,5 @@
 from typing import Callable
-from simset.initialize import init, clean, info, out, error
+from simset.initialize import init, clean, info, info_unfinished, out, error
 from simset.parser import _parse_arguments, simulate_process_parser
 from simset.simulate import simulate, simulate_setup, _get_unsimulated_args
 from simset.post_processing import post_processing
@@ -89,7 +89,10 @@ def command_line_simulate_process(
         error(args.index)
         exit(0)
     elif args.action == 'info':
-        info()
+        if args.command == "unfinished":
+            info_unfinished()
+        else:
+            info()
         exit(0)
     else:
         logger.debug("No suitable action was found")

--- a/src/simset/initialize.py
+++ b/src/simset/initialize.py
@@ -230,9 +230,28 @@ def info():
 
     unsimulated = simset._get_unsimulated_args()
 
+    # print(simset._hash_to_args[unsimulated[0]])
+
     print(
         f"""
     {len(simulated)} - simulated ({simulated_size})
     {len(unsimulated)} - unsimulated
     """
     )
+
+
+def info_unfinished():
+    """
+    print parameter configurations of unfinished simulations
+    """
+    spacing = 10  # number of fixed width for value field 
+    unsimulated = simset._get_unsimulated_args()
+
+    # print(simset._hash_to_args[unsimulated[0]])
+
+    print("\nunfinished simulations:")
+    for key in unsimulated:
+        pairs = zip(simset._hash_to_args[key][0],simset._hash_to_args[key][1])
+        print("...{}: ".format(key[-8:]) + "\t".join([f"{key}: {value}" + " " * (spacing - len(str(value))) for key, value in pairs]))
+
+    print()    

--- a/src/simset/initialize.py
+++ b/src/simset/initialize.py
@@ -230,8 +230,6 @@ def info():
 
     unsimulated = simset._get_unsimulated_args()
 
-    # print(simset._hash_to_args[unsimulated[0]])
-
     print(
         f"""
     {len(simulated)} - simulated ({simulated_size})
@@ -244,14 +242,20 @@ def info_unsimulated():
     """
     print parameter configurations of unfinished simulations
     """
-    spacing = 10  # number of fixed width for value field 
+    spacing = 10  # number of fixed width for value field
     unsimulated = simset._get_unsimulated_args()
-
-    # print(simset._hash_to_args[unsimulated[0]])
 
     print("\nunsimulated simulations:")
     for key in unsimulated:
-        pairs = zip(simset._hash_to_args[key][0],simset._hash_to_args[key][1])
-        print("...{}: ".format(key[-8:]) + "\t".join([f"{key}: {value}" + " " * (spacing - len(str(value))) for key, value in pairs]))
+        pairs = zip(simset._hash_to_args[key][0], simset._hash_to_args[key][1])
+        print(
+            "...{}: ".format(key[-8:])
+            + "\t".join(
+                [
+                    f"{key}: {value}" + " " * (spacing - len(str(value)))
+                    for key, value in pairs
+                ]
+            )
+        )
 
-    print()    
+    print()

--- a/src/simset/initialize.py
+++ b/src/simset/initialize.py
@@ -240,7 +240,7 @@ def info():
     )
 
 
-def info_unfinished():
+def info_unsimulated():
     """
     print parameter configurations of unfinished simulations
     """
@@ -249,7 +249,7 @@ def info_unfinished():
 
     # print(simset._hash_to_args[unsimulated[0]])
 
-    print("\nunfinished simulations:")
+    print("\nunsimulated simulations:")
     for key in unsimulated:
         pairs = zip(simset._hash_to_args[key][0],simset._hash_to_args[key][1])
         print("...{}: ".format(key[-8:]) + "\t".join([f"{key}: {value}" + " " * (spacing - len(str(value))) for key, value in pairs]))

--- a/src/simset/parser.py
+++ b/src/simset/parser.py
@@ -127,10 +127,10 @@ def simulate_process_parser() -> argparse.Namespace:
         help="display information about the current state of simulations",
     )
 
-    info_unfinished_parser = info_subparser.add_parser(
-        'unfinished',
-        help="shows parameter settings of unfinished simulations",
-        description="shows parameter settings of unfinished simulations",
+    info_unsimulated_parser = info_subparser.add_parser(
+        'unsimulated',
+        help="shows parameter settings of unsimulated simulations",
+        description="shows parameter settings of unsimulated simulations",
     )
 
     log = subparsers.add_parser('output', help="display simulation output")

--- a/src/simset/parser.py
+++ b/src/simset/parser.py
@@ -115,8 +115,22 @@ def simulate_process_parser() -> argparse.Namespace:
         description="runs the post_processing_function(...) function in the main.py file sequentially over all available argument combinations",
     )
 
-    subparsers.add_parser(
+    info = subparsers.add_parser(
         'info', help="display information about current state of simulations"
+    )
+
+    info_subparser = info.add_subparsers(
+        title="info",
+        dest="command",
+        required=False,
+        description="display information about the current state of the simulation",
+        help="display information about the current state of simulations",
+    )
+
+    info_unfinished_parser = info_subparser.add_parser(
+        'unfinished',
+        help="shows parameter settings of unfinished simulations",
+        description="shows parameter settings of unfinished simulations",
     )
 
     log = subparsers.add_parser('output', help="display simulation output")


### PR DESCRIPTION
Added the command 'info unsimulated' to show parameter settings of unsimulated instances.

Example: 

```> python main.py info unsimulated

unsimulated simulations:
...fc91b7ab: ratio: 1.0         s2: 1           snr: 10         rho: 0.0       
...675e6189: ratio: 1.0         s2: 1           snr: 100        rho: 0.1       
...90f3c329: ratio: 0.8         s2: 1           snr: 10         rho: 0.1       
...da302ae9: ratio: 0.85        s2: 10          snr: 10         rho: 0.1       
...dd6c4bf4: ratio: 1.0         s2: 10          snr: 10         rho: 0.1       
...1b6dc489: ratio: 0.8         s2: 1           snr: 10         rho: 0.9       
...1ffe3937: ratio: 0.95        s2: 1           snr: 10         rho: 0.9       
...aa5997c5: ratio: 0.9         s2: 10          snr: 10         rho: 0.9  
```